### PR TITLE
Fix argument order for mat4.perspective in drawSceneOnLaptopScreen()

### DIFF
--- a/lesson16/index.html
+++ b/lesson16/index.html
@@ -616,7 +616,7 @@
         gl.viewport(0, 0, rttFramebuffer.width, rttFramebuffer.height);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
-        mat4.perspective(45, laptopScreenAspectRatio, 0.1, 100.0, pMatrix);
+        mat4.perspective(pMatrix, 45, laptopScreenAspectRatio, 0.1, 100.0);
 
         gl.uniform1i(shaderProgram.showSpecularHighlightsUniform, false);
         gl.uniform3f(shaderProgram.ambientLightingColorUniform, 0.2, 0.2, 0.2);


### PR DESCRIPTION
The main scene was already updated to new mat4.perspective() syntax, but the perspective matrix for the laptop screen image still had its arguments in the older order. This change fixes the laptop screen rendering.