### PR TITLE
Update vfov parameter to use radians

### DIFF
--- a/example02/index.html
+++ b/example02/index.html
@@ -492,12 +492,11 @@
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
     // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-    mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+    mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
     // Update: mat4.translate(mvMatrix, [0, 0, -6]); mat4.translate() API has changed to mat4.translate(out, a, v)
-    // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z altered to
-    // approximate original scene.
-    mat4.translate(mvMatrix, mvMatrix, [0, 0, -4.7]);
+    // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+    mat4.translate(mvMatrix, mvMatrix, [0, 0, -6]);
 
     for (var i in cubes) {
       cubes[i].draw();

--- a/lesson01/index.html
+++ b/lesson01/index.html
@@ -147,14 +147,13 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [-1.5, 0.0, -7.0]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z altered to
-        // approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [-1.5, 0.0, -5.4]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [-1.5, 0.0, -7.0]);
         gl.bindBuffer(gl.ARRAY_BUFFER, triangleVertexPositionBuffer);
         gl.vertexAttribPointer(shaderProgram.vertexPositionAttribute, triangleVertexPositionBuffer.itemSize, gl.FLOAT, false, 0, 0);
         setMatrixUniforms();

--- a/lesson02/index.html
+++ b/lesson02/index.html
@@ -181,14 +181,13 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [-1.5, 0.0, -7.0]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z altered to
-        // approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [-1.5, 0.0, -5.4]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [-1.5, 0.0, -7.0]);
         gl.bindBuffer(gl.ARRAY_BUFFER, triangleVertexPositionBuffer);
         gl.vertexAttribPointer(shaderProgram.vertexPositionAttribute, triangleVertexPositionBuffer.itemSize, gl.FLOAT, false, 0, 0);
 

--- a/lesson03/index.html
+++ b/lesson03/index.html
@@ -206,14 +206,13 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective(pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [-1.5, 0.0, -7.0]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z altered to
-        // approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [-1.5, 0.0, -5.4]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [-1.5, 0.0, -7.0]);
 
         mvPushMatrix();
         // Update: mat4.rotate(mvMatrix, degToRad(rTri), [0, 1, 0]); mat4.rotate() API has changed to mat4.rotate(out, a, rad, axis)

--- a/lesson04/index.html
+++ b/lesson04/index.html
@@ -294,14 +294,13 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [-1.5, 0.0, -8.0]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z altered to
-        // approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [-1.5, 0.0, -6.0]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [-1.5, 0.0, -8.0]);
 
         mvPushMatrix();
         // Update: mat4.rotate(mvMatrix, degToRad(rPyramid), [0, 1, 0]); mat4.rotate() API has changed to mat4.rotate(out, a, rad, axis)

--- a/lesson05/index.html
+++ b/lesson05/index.html
@@ -286,14 +286,13 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [0.0, 0.0, -5.0]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z altered to
-        // approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [0.0, 0.0, -3.9]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [0.0, 0.0, -5.0]);
 
         // Update: mat4.rotate(mvMatrix, degToRad(xRot), [1, 0, 0]); mat4.rotate() API has changed to mat4.rotate(out, a, rad, axis)
         // where out is the receiving matrix and a is the matrix to rotate.

--- a/lesson06/index.html
+++ b/lesson06/index.html
@@ -359,7 +359,7 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 

--- a/lesson07/index.html
+++ b/lesson07/index.html
@@ -416,7 +416,7 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 

--- a/lesson08/index.html
+++ b/lesson08/index.html
@@ -418,7 +418,7 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 

--- a/lesson09/index.html
+++ b/lesson09/index.html
@@ -350,7 +350,7 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
         gl.enable(gl.BLEND);

--- a/lesson10/index.html
+++ b/lesson10/index.html
@@ -293,7 +293,7 @@
         }
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         mat4.identity(mvMatrix);
 

--- a/lesson11/index.html
+++ b/lesson11/index.html
@@ -338,7 +338,7 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         var lighting = document.getElementById("lighting").checked;
         gl.uniform1i(shaderProgram.useLightingUniform, lighting);

--- a/lesson12/index.html
+++ b/lesson12/index.html
@@ -455,7 +455,7 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         var lighting = document.getElementById("lighting").checked;
         gl.uniform1i(shaderProgram.useLightingUniform, lighting);
@@ -485,9 +485,8 @@
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [0, 0, -20]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z and
-        // DOM element "lightPositionZ" altered to approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [0, 0, -16]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [0, 0, -20]);
 
         mvPushMatrix();
         // Update: mat4.rotate(mvMatrix, degToRad(moonAngle), [0, 1, 0]); mat4.rotate() API has changed to mat4.rotate(out, a, rad, axis)
@@ -592,7 +591,7 @@
             <td><b>Location:</b>
             <td>X: <input type="text" id="lightPositionX" value="0.0" />
             <td>Y: <input type="text" id="lightPositionY" value="0.0" />
-            <td>Z: <input type="text" id="lightPositionZ" value="-16.0" />
+            <td>Z: <input type="text" id="lightPositionZ" value="-20.0" />
         </tr>
         <tr>
             <td><b>Colour:</b>

--- a/lesson13/index.html
+++ b/lesson13/index.html
@@ -533,7 +533,7 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         var perFragmentLighting = document.getElementById("per-fragment").checked;
         if (perFragmentLighting) {
@@ -574,9 +574,8 @@
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [0, 0, -5]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z and
-        // DOM element "lightPositionZ" altered to approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [0, 0, -3.9]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [0, 0, -5]);
 
         // Update: mat4.rotate(mvMatrix, degToRad(30), [1, 0, 0]); mat4.rotate() API has changed to mat4.rotate(out, a, rad, axis)
         // where out is the receiving matrix and a is the matrix to rotate.
@@ -685,7 +684,7 @@
             <td><b>Location:</b>
             <td>X: <input type="text" id="lightPositionX" value="0.0" />
             <td>Y: <input type="text" id="lightPositionY" value="0.0" />
-            <td>Z: <input type="text" id="lightPositionZ" value="-3.9" />
+            <td>Z: <input type="text" id="lightPositionZ" value="-5.0" />
         </tr>
         <tr>
             <td><b>Colour:</b>

--- a/lesson14/index.html
+++ b/lesson14/index.html
@@ -304,7 +304,7 @@
         }
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective (pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         var specularHighlights = document.getElementById("specular").checked;
         gl.uniform1i(shaderProgram.showSpecularHighlightsUniform, specularHighlights);
@@ -347,9 +347,8 @@
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [0, 0, -40]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z and
-        // DOM element "lightPositionZ" altered to approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [0, 0, -32]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [0, 0, -40]);
         // Update: mat4.rotate(mvMatrix, degToRad(23.4), [1, 0, -1]); mat4.rotate() API has changed to mat4.rotate(out, a, rad, axis)
         // where out is the receiving matrix and a is the matrix to rotate.
         mat4.rotate(mvMatrix, mvMatrix, degToRad(23.4), [1, 0, -1]);
@@ -467,7 +466,7 @@
             <td><b>Location:</b>
             <td>X: <input type="text" id="lightPositionX" value="-10.0" />
             <td>Y: <input type="text" id="lightPositionY" value="4.0" />
-            <td>Z: <input type="text" id="lightPositionZ" value="-16.0" />
+            <td>Z: <input type="text" id="lightPositionZ" value="-20.0" />
         </tr>
         <tr>
             <td><b>Specular colour:</b>

--- a/lesson15/index.html
+++ b/lesson15/index.html
@@ -338,7 +338,7 @@
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
         // Update: mat4.perspective(45, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0, pMatrix); mat4.perspective() API has changed.
-        mat4.perspective (pMatrix, 45.0, gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
+        mat4.perspective(pMatrix, glMatrix.toRadian(45.0), gl.viewportWidth / gl.viewportHeight, 0.1, 100.0);
 
         var useColorMap = document.getElementById("color-map").checked;
         gl.uniform1i(shaderProgram.useColorMapUniform, useColorMap);
@@ -381,9 +381,8 @@
         mat4.identity(mvMatrix);
 
         // Update: mat4.translate(mvMatrix, [0, 0, -40]); mat4.translate() API has changed to mat4.translate(out, a, v)
-        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by. z and
-        // DOM element "lightPositionZ" altered to approximate original scene.
-        mat4.translate(mvMatrix, mvMatrix, [0, 0, -32]);
+        // where out is the receiving matrix, a is the matrix to translate, and v is the vector to translate by.
+        mat4.translate(mvMatrix, mvMatrix, [0, 0, -40]);
         // Update: mat4.rotate(mvMatrix, degToRad(23.4), [1, 0, -1]); mat4.rotate() API has changed to mat4.rotate(out, a, rad, axis)
         // where out is the receiving matrix and a is the matrix to rotate.
         mat4.rotate(mvMatrix, mvMatrix, degToRad(23.4), [1, 0, -1]);
@@ -467,7 +466,7 @@
             <td><b>Location:</b>
             <td>X: <input type="text" id="lightPositionX" value="-10.0" />
             <td>Y: <input type="text" id="lightPositionY" value="4.0" />
-            <td>Z: <input type="text" id="lightPositionZ" value="-16.0" />
+            <td>Z: <input type="text" id="lightPositionZ" value="-20.0" />
         </tr>
         <tr>
             <td><b>Specular colour:</b>

--- a/lesson16/index.html
+++ b/lesson16/index.html
@@ -616,7 +616,7 @@
         gl.viewport(0, 0, rttFramebuffer.width, rttFramebuffer.height);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
-        mat4.perspective(45, laptopScreenAspectRatio, 0.1, 100.0, pMatrix);
+        mat4.perspective(pMatrix, glMatrix.toRadian(45.0), laptopScreenAspectRatio, 0.1, 100.0);
 
         gl.uniform1i(shaderProgram.showSpecularHighlightsUniform, false);
         gl.uniform3f(shaderProgram.ambientLightingColorUniform, 0.2, 0.2, 0.2);


### PR DESCRIPTION
mat4.perpsective() takes the vfov parameter in radians, but all the
lessons were passing in degrees. This pull request converts the
degrees in the lessons to radians, and restores the z-depth to
the values used in the original lesson.